### PR TITLE
Create forms when allowAdminChanges is false

### DIFF
--- a/src/MolliePayments.php
+++ b/src/MolliePayments.php
@@ -163,7 +163,7 @@ class MolliePayments extends Plugin
             'url' => 'mollie-payments',
         ];
 
-        if (Craft::$app->getUser()->getIsAdmin() && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
+        if (Craft::$app->getUser()->getIsAdmin()) {
             $subNavs['forms'] = [
                 'label' => 'Forms',
                 'url' => 'mollie-payments/forms',


### PR DESCRIPTION
Currently on any environment where `allowAdminChanges` is set to `false` you can't access the Forms settings page. Thus, no way to add payment forms. This could be a temporary (?) fix until the payment forms are compatible with project config.