### PR TITLE
Fixed foreign key error on payment

### DIFF
--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -71,6 +71,7 @@ class PaymentController extends Controller
             $payment->email = $email;
             $payment->amount = $amount;
             $payment->formId = $paymentForm->id;
+            $payment->fieldLayoutId = $paymentForm->fieldLayout;
         }
 
         $payment->paymentStatus = 'pending';

--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -4,7 +4,6 @@ namespace studioespresso\molliepayments\controllers;
 
 use Craft;
 use craft\base\Element;
-use craft\base\Model;
 use craft\helpers\ConfigHelper;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
@@ -65,14 +64,13 @@ class PaymentController extends Controller
             $paymentForm = MolliePayments::getInstance()->forms->getFormByHandle($form);
             $payment = new Payment();
 
-            $payment->email = $email;
-            $payment->amount = $amount;
-            $payment->formId = $form;
-            $payment->fieldLayoutId = $paymentForm->fieldLayout;
-
             if (!$paymentForm) {
                 throw new NotFoundHttpException("Form not found", 404);
             }
+
+            $payment->email = $email;
+            $payment->amount = $amount;
+            $payment->formId = $paymentForm->id;
         }
 
         $payment->paymentStatus = 'pending';


### PR DESCRIPTION
When installing the Plugin I noticed that the documentation and code didn't match. It seems like the documentation is updated to v2.0.0, but the package isn't released yet.

After using the `dev-develop` version, an database error occurred on a relation between the payment and the form. The `form` variable in the payment action is now (in v2.0.0) used for the handle, not the form id, but the code wasn't updated yet to reflect that change.

Also, when a Form couldn't be found, there would be an error because the value of `$paymentForm` is checked _after_ using it.