### PR TITLE
fix error if no subscriber found

### DIFF
--- a/src/variables/MollieVariable.php
+++ b/src/variables/MollieVariable.php
@@ -12,12 +12,18 @@ class MollieVariable
     public function getSubscriptionsByUid($uid)
     {
         $subscriber = SubscriberRecord::findOne(['uid' => $uid]);
+        if(!$subscriber) {
+            return [];
+        }
         return Subscription::findAll(['email' => $subscriber->email]);
     }
 
     public function getSubscriptionsByUser(User $user)
     {
         $subscriber = SubscriberRecord::findOne(['userId' => $user->id]);
+        if(!$subscriber) {
+            return [];
+        }
         return Subscription::findAll(['email' => $subscriber->email]);
     }
 


### PR DESCRIPTION
When using the functions getSubscriptionsByUser or getSubscriptionsByUid you get an error if the user has no subscriptions. 

This occurs because after checking the records there is no return and we try to get the email on a null object.

Fixed this by adding an empty array as return object if there is no record found. 