### PR TITLE
[Bug] 500 error when failing to update transaction after payment.

### DIFF
--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -279,7 +279,9 @@ class PaymentController extends Controller
             }
             return $this->asSuccess("Transaction already up to date", [], $redirect);
         } catch (\Throwable $e) {
-            return $this->asFailure("Something went wrong checking the status for this payment");
+            Craft::error("Error checking transaction status for {$id}: " . $e->getMessage() . "\n" . $e->getTraceAsString(), 'mollie-payments');
+            $this->setFailFlash("Something went wrong checking the status for this payment: " . $e->getMessage());
+            return $this->redirect($redirect);
         }
     }
 

--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -279,7 +279,7 @@ class PaymentController extends Controller
             }
             return $this->asSuccess("Transaction already up to date", [], $redirect);
         } catch (\Throwable $e) {
-            return $this->asFailure("Something went wrong checking the status for this payment", [], $redirect);
+            return $this->asFailure("Something went wrong checking the status for this payment");
         }
     }
 

--- a/src/controllers/PaymentController.php
+++ b/src/controllers/PaymentController.php
@@ -273,7 +273,7 @@ class PaymentController extends Controller
             $form = MolliePayments::getInstance()->forms->getFormByid($element->formId);
             $molliePayment = MolliePayments::getInstance()->mollie->getStatus($id, $form->handle);
 
-            if ($transaction->status !== $molliePayment->status) {
+            if ($transaction->status !== $molliePayment->status || $element->paymentStatus !== $molliePayment->status) {
                 MolliePayments::getInstance()->transaction->updateTransaction($transaction, $molliePayment);
                 return $this->asSuccess("Transaction status updated", [], $redirect);
             }

--- a/src/services/Transaction.php
+++ b/src/services/Transaction.php
@@ -28,8 +28,9 @@ class Transaction extends Component
     {
         $transaction->status = $molliePayment->status;
         $transaction->method = $molliePayment->method;
+        $refundAmount = null;
         if ($molliePayment->refunds()->count > 0) {
-            $transaction->refundAmount = $molliePayment->getAmountRefunded()->value;
+            $refundAmount = $molliePayment->getAmountRefunded()->value;
             if ($molliePayment->getAmountRefunded() < $molliePayment->getSettlementAmount()) {
                 $transaction->status = "partially refunded";
             } elseif ($molliePayment->getAmountRefunded() === $molliePayment->getSettlementAmount()) {
@@ -53,7 +54,7 @@ class Transaction extends Component
             } else {
                 $element = Payment::findOne(['id' => $transaction->payment]);
                 $element->paymentStatus = $transaction->status;
-                $element->refundAmount = $transaction->refundAmount;
+                $element->refundAmount = $refundAmount;
                 Craft::$app->getElements()->saveElement($element);
             }
             $this->fireEventAfterTransactionUpdate($transaction, $element, $molliePayment->status);


### PR DESCRIPTION
The $this->asFailure method does not take a redirect url as 3d parameter but takes routeParams. Giving nothing will result to default and send back the user to the previous page which is what we want. 

Also the if statement is added because if the status'es are not in sync you can never update the payment anymore. 